### PR TITLE
user functionality added along with user permissions for other tools

### DIFF
--- a/app/Http/Controllers/ChurchUsersController.php
+++ b/app/Http/Controllers/ChurchUsersController.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use App\Invite;
+use App\User;
+use App\Mail\InviteCreated;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
+
+
+class ChurchUsersController extends Controller
+{
+   
+    public function index()
+    {
+        $user = Auth::user();
+        $church = $user->church;
+        $churchusers = $church->users()->where('id', '!=', $church->admin_id)->get();
+        return view('settings.manageusers', compact('church', 'user', 'churchusers'));
+    }
+    public function sendInvite(Request $request)
+    {
+        $user = Auth::user();
+        $church = $user->church;
+
+        $validatedData = $request->validate([
+            'name' => 'required | min:5 | max:40',
+            'email' => 'required | unique:userbase.users,email',
+        ]);
+
+        do {
+            //generate a random string using Laravel's str_random helper
+            $token = Str::random(15);
+        } //check if the token already exists and if it does, try again
+        while (Invite::where('token', $token)->first());
+    
+        //create a new invite record
+        $invite = Invite::create([
+            'name' => $request->get('name'),
+            'email' => $request->get('email'),
+            'church_id' => $church->id,
+            'token' => $token
+        ]);
+    
+        // send the email
+        Mail::to($request->get('email'))->send(new InviteCreated($invite));
+
+        $request->session()->flash('alert', "We've sent an invite to the email you provided.  We'll let you know via email when the user registers.");
+        // redirect back where we came from
+        return redirect()
+            ->back();
+    }
+    public function updatePermissions(User $user, Request $request)
+    {
+        if($user->permissions->sermon_admin)
+        {
+            $user->permissions->update(['sermons_admin' => 0]);
+        }
+        else
+        {
+            $user->permissions->update(['sermons_admin' => 1]);
+        }
+        $request->session()->flash('permissionschanged', "We've updated that user's permissions.");
+        return redirect()
+            ->back();
+    }
+    public function destroy(User $user, Request $request)
+    {
+        $user->delete();
+        $request->session()->flash('permissionschanged', "We've deleted the user.");
+        return redirect()
+            ->back();
+    }
+}

--- a/app/Http/Controllers/InviteController.php
+++ b/app/Http/Controllers/InviteController.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Invite;
+use App\Church;
+use App\User;
+use App\Mail\Invitecompleted;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Hash;
+
+class InviteController extends Controller
+{
+    /**
+     * Create a new controller instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->middleware('guest');
+    }
+
+    public function showInvitedUserForm($token)
+    {
+        // Look up the invite
+        if (!$invite = Invite::where('token', $token)->first()) {
+        //if the invite doesn't exist do something more graceful than this
+        abort(404);
+        }
+        $invite = Invite::where('token', $token)->first();
+        // Show a signup form for that church
+        $church = Church::find($invite->church_id);
+        return view('auth.invite-form', compact('token', 'church', 'invite'));
+    }
+
+    public function acceptInvitedUser(Request $request, $token)
+    {
+        // Make sure this is actually an invited user using the token
+        if (!$invite = Invite::where('token', $token)->first()) {
+        //if the invite doesn't exist do something more graceful than this
+        abort(404);
+        }
+        
+        // Validate the user data
+        $validatedData = $request->validate([
+            'name' => 'required | min:5 | max:40',
+            'email' => 'required | unique:userbase.users,email',
+            'password' => 'required',
+            'password_confirmation' => 'nullable | same:password'
+        ]);
+
+         // create the user with the details from the invite
+        $user = User::create([
+            'name' => $request->name,
+            'email' => $request->email,
+            'church_id' => $invite->church_id,
+            'password' => Hash::make($request->password)
+            ]);
+
+        $user->permissions()->create([
+            'sermons_admin' => 1
+        ]);
+
+        // Email the admin to let the know the new user is created.
+        Mail::to($user->church->admin->email)->send(new InviteCompleted($user));
+        // delete the invite so it can't be used again
+        $invite->delete();
+        
+        // Redirect the user to the login page.
+        return redirect('/login');
+
+        
+
+    }
+}

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -59,6 +59,7 @@ class SettingsController extends Controller
         $church = $user->church;
         return view('settings.user', compact('church', 'user'));
     }
+   
     public function userchange(Request $request)
     {
         $user = Auth::user();
@@ -120,4 +121,5 @@ class SettingsController extends Controller
         $church->settings->save();
         return redirect('/settings/homepage');
     }
+    
 }

--- a/app/Invite.php
+++ b/app/Invite.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Invite extends Model
+{
+    protected $connection = 'userbase';
+    protected $fillable = [
+    'email', 'church_id', 'token', 'name'
+    ];
+
+}

--- a/app/Mail/InviteCompleted.php
+++ b/app/Mail/InviteCompleted.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+use App\User;
+
+class InviteCompleted extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public $user;
+
+    public function __construct(User $user)
+    {
+        $this->user = $user;
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->markdown('emails.invitecompleted');
+    }
+}

--- a/app/Mail/InviteCreated.php
+++ b/app/Mail/InviteCreated.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+use App\Invite;
+use App\Church;
+
+class InviteCreated extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public $invite;
+    public $church;
+
+    public function __construct(Invite $invite)
+    {
+        $this->invite = $invite;
+        $this->church = Church::find($invite->church_id);
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->from('users@churchtools.co')
+                ->markdown('emails.invite');
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -49,4 +49,12 @@ class User extends Authenticatable
         $lastInitial = $usernamearray[1] ? substr($usernamearray[1], 0, 1) : '';
         return "{$firstInitial}{$lastInitial}";
     }
+    public function isAdmin()
+    {
+       return $this->church->admin_id == $this->id ? true : false ;
+    }
+    public function permissions()
+    {
+        return $this->hasOne(UserPermission::class);
+    }
 }

--- a/app/UserPermission.php
+++ b/app/UserPermission.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class UserPermission extends Model
+{
+    protected $connection = 'userbase';
+    protected $guarded = [];
+    public function user()
+    {
+        return $this->hasOne(User::class);
+    }
+    //
+}

--- a/database/migrations/2019_11_04_124046_create_invites_table.php
+++ b/database/migrations/2019_11_04_124046_create_invites_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateInvitesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::connection('userbase')->create('invites', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name');
+            $table->string('email');
+            $table->unsignedBigInteger('church_id');
+            $table->string('token', 16)->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('invites');
+    }
+}

--- a/database/migrations/2019_11_04_145508_create_user_permissions_table.php
+++ b/database/migrations/2019_11_04_145508_create_user_permissions_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUserPermissionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::connection('userbase')->create('user_permissions', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('user_id');
+            $table->boolean('sermons_admin')->default(0);
+            $table->boolean('prayer_admin')->default(0);
+            $table->boolean('prayer_user')->default(1);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('user_permissions');
+    }
+}

--- a/resources/views/auth/invite-form.blade.php
+++ b/resources/views/auth/invite-form.blade.php
@@ -1,0 +1,101 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="container mx-auto">
+        <div class="flex flex-wrap justify-center">
+            <div class="w-full max-w-lg mt-24">
+                <div class="flex flex-col break-words ">
+
+                    <div class="font-bold text-2xl py-3 text-center mb-6 text-gray-800">
+                        {{ __('Register For ChurchTools.co') }}
+                    </div>
+                    @if(session('status'))
+                    @component('includes.note', ['color' => 'red'])
+                    {{ session('status') }}
+                    @endcomponent
+                    @endif 
+                    <form class="w-full" method="POST" action="{{ route('register-invite', $invite->token) }}">
+                        @csrf
+                        <div class="max-w-lg flex flex-col items-center mx-auto mb-12 border rounded p-6">
+                        {{-- <h2 class="text-lg font-bold mb-6 text-center w-full">{{ __('Tell Us About Yourself') }}</h2> --}}
+                            <div class="flex flex-wrap mb-6">
+                                <label class="block w-full">
+                                    <span class="text-gray-700">{{ __('Name') }}:</span>
+                                    <input class="form-input mt-1 block w-64" placeholder="Jane Doe" id="name" type="text" name="name" value="{{ old('name') }}" required autofocus>
+                                </label>
+                            </div>
+                              @if ($errors->has('name'))
+                                    @component('includes.note', ['color' => 'red'])
+                                    <p>
+                                        {{ $errors->first('name') }}
+                                    </p>
+                                    @endcomponent
+                              @endif
+                              
+                            <div class="flex flex-wrap mb-6">
+                            <label class="block w-full">
+                                    <span class="text-gray-700">  {{ __('E-Mail Address') }}:</span>
+                                    <input class="form-input mt-1 block w-64" placeholder="Jane Doe" id="email" type="text" name="email" value="{{ old('email') }}" required>
+                            </label>
+                            </div>
+                              @if ($errors->has('email'))
+                                    @component('includes.note', ['color' => 'red'])
+                                    <p>
+                                        {{ $errors->first('email') }}
+                                    </p>
+                                    @endcomponent
+                              @endif
+
+                         
+                                <label class="block w-64 mb-6 mx-auto " >
+                                        <span class="text-gray-700"> {{ __('Password') }}:</span>
+                                        <input class="form-input mt-1 block w-64" id="password" type="password"  name="password" value="{{ old('password') }}" required>
+                                </label>
+                                <label class="block w-64 mx-auto">
+                                        <span class="text-gray-700"> {{ __('Confirm Password') }}:</span>
+                                        <input class="form-input mt-1 block w-64" id="password-confirm" type="password"  name="password_confirmation"  required>
+                                </label>
+                              
+
+                              @if ($errors->has('password'))
+                                    @component('includes.note', ['color' => 'red'])
+                                    <p>
+                                        {{ $errors->first('password') }}
+                                    </p>
+                                    @endcomponent
+                              @endif
+
+                              <div class="flex my-6">
+                                <label class="flex items-center">
+                                    <input type="checkbox" class="form-checkbox" name="terms">
+                                    <span class="ml-2">I agree to the <a class="underline" href="/terms" target="_blank">terms and statement of faith</a></span>
+                                </label>
+                            </div>
+                            @if ($errors->has('terms'))
+                                    @component('includes.note', ['color' => 'red'])
+                                    <p>
+                                        {{ $errors->first('terms') }}
+                                    </p>
+                                    @endcomponent
+                              @endif
+                        </div>
+                        
+                        <div class="flex flex-wrap w-full justify-center">
+                            <button type="submit" class="block w-full align-middle text-center select-none border font-bold whitespace-no-wrap py-2 px-4 rounded text-base leading-normal no-underline text-gray-100 bg-blue-500 hover:bg-blue-700">
+                                {{ __('Register') }}
+                            </button>
+
+                            <p class="w-full text-xs text-center text-gray-700 my-8 ">
+                                Already have an account?
+                                <a class="text-blue-500 hover:text-blue-700 no-underline" href="{{ route('login') }}">
+                                    Login
+                                </a>
+                            </p>
+                        </div>
+                    </form>
+
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/emails/invite.blade.php
+++ b/resources/views/emails/invite.blade.php
@@ -1,0 +1,8 @@
+@component('mail::message')
+# {{$church->admin->name}} has invited you to help administrate sermons for {{$church->name}}.
+
+Please click <a href="{{ route('accept', $invite->token) }}">this link</a> to setup your account and password.
+
+Thanks,<br>
+{{ config('app.name') }}
+@endcomponent

--- a/resources/views/emails/invitecompleted.blade.php
+++ b/resources/views/emails/invitecompleted.blade.php
@@ -1,0 +1,8 @@
+@component('mail::message')
+# {{$user->name}} has completed signup for Church Tools Sermons.
+
+You had previously invited {{$user->name}} to help manage Church Tools Sermons.  We just wanted to let you know he/she has signed up.  You can always remove his/her account by signing in and going to settings/users.
+
+Thanks,<br>
+{{ config('app.name') }}
+@endcomponent

--- a/resources/views/settings/inc/adduserform.blade.php
+++ b/resources/views/settings/inc/adduserform.blade.php
@@ -1,0 +1,35 @@
+<form action="/settings/users" method="POST" class="max-w-lg mx-auto mb-6">
+		<h2 class="font-bold text-xl mb-4 ">Invite Another User</h2> 
+	 	@csrf 
+	 	<label class="block mb-6">
+		  <span class="text-gray-700">{{ __("Name") }}</span>
+		  <input class="form-input mt-1 block w-full" placeholder="John Doe" name="name">
+		</label>
+		 @if ($errors->has('name'))
+	            @component('includes.note', ['color' => 'red'])
+	            <p>
+	                {{ $errors->first('name') }}
+	            </p>
+	            @endcomponent
+		  @endif
+		  <label class="block mb-6">
+		  <span class="text-gray-700">{{ __("Email") }}</span>
+		  <input class="form-input mt-1 block w-full" type="email" placeholder="johndoe@gmail.com" name="email" >
+		</label>
+		 @if ($errors->has('email'))
+	            @component('includes.note', ['color' => 'red'])
+	            <p>
+	                {{ $errors->first('email') }}
+	            </p>
+	            @endcomponent
+	      @endif
+		
+		<button type="submit" class="w-full mb-6 text-white bg-green-500 py-2 text-center rounded text-lg uppercase tracking-wide hover:bg-green-400">Send Invite</button>
+		@if(session('alert'))
+		@component('includes.note', ['color' => 'green'])
+	            <p>
+	                {{ session('alert') }}
+	            </p>
+	            @endcomponent
+		@endif
+	 </form>

--- a/resources/views/settings/inc/nav.blade.php
+++ b/resources/views/settings/inc/nav.blade.php
@@ -4,6 +4,8 @@
 	{{-- <li class="text-lg {{ $active == 'style' ? 'font-bold text-green-500' : '' }}"><a class="inline-flex items-center hover:underline" href="/settings/style">@component('svg.color-palette') h-4 mr-2 @endcomponent {{ __("Style") }}</a></li> --}}
 	<li class="text-lg {{ $active == 'homepage' ? 'font-bold text-green-500' : '' }}"><a class="inline-flex items-center hover:underline" href="/settings/homepage">@component('svg.home') h-4 mr-2 @endcomponent {{ __("Home Page") }}</a></li>
 	<li class="text-lg {{ $active == 'podcast' ? 'font-bold text-green-500' : '' }}"><a class="inline-flex items-center hover:underline" href="/settings/podcast">@component('svg.playlist') h-4 mr-2 @endcomponent {{ __("Podcast") }}</a></li>
-	{{-- <li class="text-lg {{ $active == 'users' ? 'font-bold text-green-500' : '' }}"><a class="inline-flex items-center hover:underline" href="/settings/users">@component('svg.user-add') h-4 mr-2 @endcomponent {{ __("Users") }}</a></li> --}}
+	@if($user->isAdmin())
+	<li class="text-lg {{ $active == 'users' ? 'font-bold text-green-500' : '' }}"><a class="inline-flex items-center hover:underline" href="/settings/users">@component('svg.user-add') h-4 mr-2 @endcomponent {{ __("Users") }}</a></li>
+	@endif
 	{{-- <li class="text-lg {{ $active == 'notifications' ? 'font-bold text-green-500' : '' }}"><a class="inline-flex items-center hover:underline" href="/settings/notifications">@component('svg.notifications') h-4 mr-2 @endcomponent {{ __("Notifications") }}</a></li> --}}
 </ul>

--- a/resources/views/settings/inc/usermanage.blade.php
+++ b/resources/views/settings/inc/usermanage.blade.php
@@ -1,0 +1,21 @@
+{{--accepts $cuser from foreach loop --}}
+<div class="w-full bg-white p-4 border-b flex">
+    <p class="text-sm mr-6 font-bold">{{$cuser->name}}</p>
+    <p class="text-sm">{{$cuser->email}}</p>
+    <div class="actions flex-grow flex justify-end items-center">
+        <form action="/manageuserpermissions/{{$cuser->id}}" method="POST" class="mr-6" id="permission{{$cuser->id}}">
+        @csrf   
+        @method('PUT')
+        <label class="inline-flex items-center">
+            <input type="checkbox" class="form-checkbox border-gray-500" onclick="document.querySelector('#permission{{$cuser->id}}').submit()" name="managesermons" {{ $cuser->permissions->sermons_admin ? 'checked' : ''}}>
+        </label>
+      </form>
+      <form action="/deleteuser/{{$cuser->id}}" method="POST" id="delete{{$cuser->id}}">
+        @csrf 
+        @method('DELETE')
+        <button type="button" onclick="deleteuser({{$cuser->id}})">
+            @component('svg.trash') text-red-700 h-4 @endcomponent
+        </button>
+        </form>
+    </div>
+</div>

--- a/resources/views/settings/manageusers.blade.php
+++ b/resources/views/settings/manageusers.blade.php
@@ -1,0 +1,54 @@
+@extends('layouts.settings')
+@section('sermonsContent')
+<div class="w-full max-w-4xl mx-auto mt-24 text-gray-800">
+<div class="flex justify-between  items-baseline p-6 md:p-0 md:mb-12">
+ <h1 class="text-3xl font-bold text-blue-500 flex-grow">{{  __('Settings') }}</h1>   
+</div>
+<div class="content flex p-6 flex-wrap md:flex-no-wrap md:p-0">
+<aside class="w-full pb-8 border-b mb-8  md:border-b-0 md:w-auto md:flex-shrink-0 md:border-r md:pr-8">
+@include('settings.inc.nav', ['active' => 'users'])
+</aside>
+<main class="flex-grow md:px-8">
+	 @include('settings.inc.adduserform')
+	<section class="manageusers max-w-lg mx-auto">
+	<h2 class="font-bold text-xl mb-4 ">Manage Users</h2>
+	@component('includes.note', ['color' => 'blue'])
+	<p>Click the checkbox to grant or deny permission to manage sermons.  Click the trash can to remove the user.</p>
+	@endcomponent
+	@foreach($churchusers as $cuser)
+	@include('settings.inc.usermanage')
+	@endforeach 
+
+	@if(session('permissionschanged'))
+	<div class="mt-6">
+	@component('includes.note', ['color' => 'green'])
+	<p>{{session('permissionschanged') }} </p>
+	@endcomponent
+	</div>
+	@endif
+	<script>
+	var deleteuser = (userid) => {
+		var form = document.querySelector(`#delete${userid}`);
+		swal({
+      title: "Are you sure?",
+      text: "Once deleted, you will not be able to recover this user!",
+      icon: "warning",
+      buttons: true,
+      dangerMode: true,
+    })
+    .then((willDelete) => {
+      if (willDelete) {
+        form.submit();
+      } 
+    });
+	}
+	</script>
+	</section>
+</main>
+</div>	
+</div>
+
+@endsection
+@push('scripts')
+<script src="https://unpkg.com/sweetalert/dist/sweetalert.min.js"></script>
+@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,6 +35,9 @@ Route::get('/sermon/{church}/latest', 'PublicSermonsController@latest');
 Route::get('/sermon/{church}/currentseries', 'PublicSermonsController@currentSeries');
 Route::get('/churches/{church}/{type}/series', 'PublicSeriesController@index');
 Route::get('/churches/{church}/{type}/series/{series}', 'PublicSeriesController@show');
+Route::get('/acceptUserInvite/{token}', 'InviteController@showInvitedUserForm')->name('accept');
+Route::post('/acceptUserInvite/{token}', 'InviteController@acceptInvitedUser')->name('register-invite');
+
 Route::middleware(['auth'])->group(function () {
 
     Route::get('/home', 'SermonsController@index')->name('home');
@@ -59,9 +62,13 @@ Route::middleware(['auth'])->group(function () {
     Route::put('/settings/user', 'SettingsController@userchange');
     Route::get('/settings/podcast', 'SettingsController@podcast');
     Route::put('/settings/podcast', 'SettingsController@podcastchange');
+    Route::get('/settings/users', 'ChurchUsersController@index');
+    Route::post('/settings/users', 'ChurchUsersController@sendInvite');
     Route::get('/embeds', 'EmbedsController@index');
     Route::get('/embeds/widgets', 'EmbedsController@widgets');
     Route::get('/embeds/full', 'EmbedsController@full');
     Route::delete('/settings/podcast/removeimage', 'SettingsController@removePodcastImage');
     Route::delete('/settings/homepage/removeimage', 'SettingsController@removeHomePageImage');
+    Route::put('/manageuserpermissions/{user}', 'ChurchUsersController@updatePermissions')->name('update-permissions');
+    Route::delete('/deleteuser/{user}', 'ChurchUsersController@destroy')->name('delete-user');
 });


### PR DESCRIPTION
This PR adds the following abilities:

1. The "owner" of the church account can send invites to other users.
2. When a user responds to that email, the "owner" is notified via email.
3. Under /settings/users the "owner" can delete these users or revoke their permissions to manage sermons.